### PR TITLE
support nonce for 'init' for CSP

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -114,13 +114,20 @@ The `init` variable will look like this:
 </script>
 ```
 
-The function `bottlereact._onLoad` (defined in `bottlereact.js`) takes a list of classes that need to load before the compnent can be rendered, and a callback to be run when they are loaded.  the callback contains normal React code to initialize your component.
+The function `bottlereact._onLoad` (defined in `bottlereact.js`) takes a list of classes that need to load before the component can be rendered, and a callback to be run when they are loaded.  the callback contains normal React code to initialize your component.
 
 We talked internally about (in `prod` mode) having `render_html()` taking advantage of React's ability to pre-render the HTML, but in testing we've found the brower renders the JSX extremely fast already.  So we haven't done it yet, but it's designed to be added in the future.
 
 If you want to use another template, pass in `template='template_fn'` into `render_html()` and bottle-react will use that template instead.
 
-Any additional `kwargs` passed into `render_html()` will be passed through to the template.  For example, `title='My Site'` is very common.
+Any additional `kwargs` passed into `render_html()` will be passed through to the template.  For example, `title='My Site'` is very common. Another useful one to include is `init_nonce`, which will change the `init` script tag to be declared as:
+```html
+<script nonce="{init_nonce}">
+   ...
+</script>
+```
+
+This allows you to use Content Security Policy headers with `BottleReact`. Because `default_render_html_kwargs` can be a function called at each render, it is easy to create the nonce from the same state for use here and in the CSP header.
 
 
 ## jsx_props.py

--- a/bottlereact.py
+++ b/bottlereact.py
@@ -420,8 +420,10 @@ class BottleReact(object):
       else: # assume javascript
         deps_html.append('<script src="%s"></script>' % bottle.html_escape(path))
     deps_html = '\n'.join(deps_html)
+    init_nonce = kwargs.get('init_nonce', None)
+    init_nonce = ' nonce="%s"' % init_nonce if init_nonce else ''
     init = '''
-    <script>
+    <script%s>
       bottlereact._onLoad(%s, function() {
         ReactDOM.render(
           %s,
@@ -429,7 +431,7 @@ class BottleReact(object):
         );
       });
     </script>
-    ''' % (classes, react_js)
+    ''' % (init_nonce, classes, react_js)
     if 'title' not in kwargs: kwargs['title'] = 'bottle-react - https://github.com/keredson/bottle-react'
     kwargs.update({
       'deps': deps_html,


### PR DESCRIPTION
Including the kwarg `init_nonce` will embed that value as the nonce for the init script so that sites with CSP enabled can omit `unsafe-inline` scripts.